### PR TITLE
Tweak runtime dependencies(activerecord and activesupport)

### DIFF
--- a/activerecord-mysql-unsigned.gemspec
+++ b/activerecord-mysql-unsigned.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "database_cleaner"
-  spec.add_runtime_dependency "activesupport", ">= 3.2", "<= 4.1"
-  spec.add_runtime_dependency "activerecord", ">= 3.2", "<= 4.1"
+  spec.add_runtime_dependency "activesupport", ">= 3.2", "< 4.2"
+  spec.add_runtime_dependency "activerecord", ">= 3.2", "< 4.2"
   spec.add_runtime_dependency "mysql2"
 end


### PR DESCRIPTION
Supports security fix of Rails v4.1.1

ref: [Rails 3.2.18, 4.0.5 and 4.1.1 have been released!](http://weblog.rubyonrails.org/2014/5/6/Rails_3_2_18_4_0_5_and_4_1_1_have_been_released/)

:bow: :bow: :bow: 
