### PR TITLE
Changed syntax of symbolic hash for Ruby 1.8 compatibility

### DIFF
--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class AbstractMysqlAdapter < AbstractAdapter
 
       NATIVE_DATABASE_TYPES.merge!(
-        primary_key: "int(10) unsigned DEFAULT NULL auto_increment PRIMARY KEY"
+        :primary_key => "int(10) unsigned DEFAULT NULL auto_increment PRIMARY KEY"
       )
  
       # Maps logical Rails types to MySQL-specific data types.

--- a/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           options = o.options
           sql_type = type_to_sql(o.type, options[:limit], options[:precision], options[:scale], options[:unsigned])
           change_column_sql = "CHANGE #{quote_column_name(column.name)} #{quote_column_name(options[:name])} #{sql_type}"
-          add_column_options!(change_column_sql, options.merge(column: column))
+          add_column_options!(change_column_sql, options.merge(:column => column))
           add_column_position!(change_column_sql, options)
         end
 


### PR DESCRIPTION
I don't think Ruby 1.8 compatibility should be a major goal, but as long as it's a low hanging fruit ...
