### PR TITLE
Call original type_to_sql when signed

### DIFF
--- a/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
@@ -92,6 +92,7 @@ module ActiveRecord
           type_to_sql_without_unsigned(type, limit, precision, scale)
         end
       end
+      alias_method_chain :type_to_sql, :unsigned
 
     end
   end

--- a/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
@@ -42,7 +42,7 @@ module ActiveRecord
       # Maps logical Rails types to MySQL-specific data types.
       def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = false)
         # return earlier, only need overwrite method when unsigned option == true
-        return super unless unsigned
+        return type_to_sql_without_unsigned(type, limit, precision, scale) unless unsigned
 
 
         case type.to_s
@@ -89,7 +89,7 @@ module ActiveRecord
           else raise(ActiveRecordError, "No integer type has byte size #{limit}")
           end
         else
-          super
+          type_to_sql_without_unsigned(type, limit, precision, scale)
         end
       end
 

--- a/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4_1/connection_adapters/abstract_mysql_adapter.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       )
 
       # Maps logical Rails types to MySQL-specific data types.
-      def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = false)
+      def type_to_sql_with_unsigned(type, limit = nil, precision = nil, scale = nil, unsigned = false)
         # return earlier, only need overwrite method when unsigned option == true
         return type_to_sql_without_unsigned(type, limit, precision, scale) unless unsigned
 


### PR DESCRIPTION
When type_to_sql is called without unsigned, processing of bigint is not performed correctly.

Following is expected to be `any_num bigint,`:

``` ruby
create_table("any_table") do |t|
  t.integer("any_num", {:limit=>5})
# => CREATE TABLE `any_table` (... `any_num` int(5),
```

Please merge if there is no problem :bow: 
