### PR TITLE
add :bigint option support

### DIFF
--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -83,7 +83,7 @@ module ActiveRecord
           end.tap do |sql_type|
             sql_type << ' unsigned' if unsigned
           end
-        when 'float', 'decimal'
+        when 'float', 'decimal', 'bigint'
           type_to_sql_without_unsigned(type, limit, precision, scale).tap do |sql_type|
             sql_type << ' unsigned' if unsigned
           end

--- a/spec/support/migrations.rb
+++ b/spec/support/migrations.rb
@@ -38,6 +38,7 @@ class CreateUsersTable < ActiveRecord::Migration
       t.integer :will_bigint
       t.decimal :signed_decimal, null: false, default: 0, precision: 15, scale: 2
       t.decimal :unsigned_decimal, null: false, default: 0, unsigned: true, precision: 15, scale: 2
+      t.integer :will_unsigned_bigint
     end
   end
 end
@@ -55,6 +56,7 @@ class ChangeColumnToUsersTable < ActiveRecord::Migration
     change_column :users, :will_unsigned_int, :integer, unsigned: true
     change_column :users, :will_signed_int,   :integer, unsigned: false
     change_column :users, :will_bigint,       :integer, limit: 8
+    change_column :users, :will_unsigned_bigint, :integer, limit: 8, unsigned: true
   end
 end
 

--- a/spec/support/migrations.rb
+++ b/spec/support/migrations.rb
@@ -56,7 +56,7 @@ class ChangeColumnToUsersTable < ActiveRecord::Migration
     change_column :users, :will_unsigned_int, :integer, unsigned: true
     change_column :users, :will_signed_int,   :integer, unsigned: false
     change_column :users, :will_bigint,       :integer, limit: 8
-    change_column :users, :will_unsigned_bigint, :integer, limit: 8, unsigned: true
+    change_column :users, :will_unsigned_bigint, :bigint, unsigned: true
   end
 end
 


### PR DESCRIPTION
Sorry for my poor English...
Please tell me "日本語でおｋ".
## 動作確認環境
- ruby ver 2.1.5
- rails ver 4.1.9
## 概要

既存テーブルのカラム属性変更migrationで型をbigintにしたい場合、下記の2通りの書き方が可能です。

``` ruby
# case A
change_column :hoge_tbl, :huga_id, :integer, limit: 8, unsigned: true

# case B
change_column :hoge_tbl, :huga_id, :bigint, unsigned: true
```

現状、前者の書き方と後者の書き方で、`db:migrate`実行後の`db/schema.rb`の出力内容に下記の差異が発生します。

``` bash
$ bundle exec rake db:migrate
$ cat db/schema.rb
```

``` ruby
# case A
t.integer  "huga_id",    limit: 8, null: false, unsigned: true

# case B  *** not print "unsigned: true"
t.integer  "huga_id",    limit: 8, null: false
```

case Bでも "unsigned: true" が出力されるよう修正しました
